### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SoyiGit
-####Author:Ezreal Wang
-####Blog:[http://blog.csdn.net/ddwhan0123](http://blog.csdn.net/ddwhan0123) 
-####QQ:526357367
-####WeChat ID:<br>![WeChatID](https://github.com/ddwhan0123/SoyiGit/blob/master/Soyi/WeChatID.JPG "二维码")
+#### Author:Ezreal Wang
+#### Blog:[http://blog.csdn.net/ddwhan0123](http://blog.csdn.net/ddwhan0123) 
+#### QQ:526357367
+#### WeChat ID:<br>![WeChatID](https://github.com/ddwhan0123/SoyiGit/blob/master/Soyi/WeChatID.JPG "二维码")
 >已完成模块:clap::clap::clap:
 >>0.引导页面/Guide page
 >>>版本号/AppVersion


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
